### PR TITLE
Change class name from Settings to Setting

### DIFF
--- a/lib/activeadmin_settings_cached.rb
+++ b/lib/activeadmin_settings_cached.rb
@@ -2,7 +2,7 @@ require "activeadmin_settings_cached/engine"
 
 module ActiveadminSettingsCached
   mattr_accessor :settings_class
-  self.settings_class = "Settings"
+  self.settings_class = "Setting"
 
   class << self
     def settings_klass


### PR DESCRIPTION
To follow rails conventions, the model should be singular.
